### PR TITLE
Avoid calling endswith in a bytes passing a str.

### DIFF
--- a/desktop/__init__.py
+++ b/desktop/__init__.py
@@ -136,7 +136,7 @@ def _is_xfce():
     # XFCE detection involves testing the output of a program.
 
     try:
-        return _readfrom(_get_x11_vars() + "xprop -root _DT_SAVE_MODE", shell=1).strip().endswith(' = "xfce4"')
+        return _readfrom(_get_x11_vars() + "xprop -root _DT_SAVE_MODE", shell=1).strip().endswith(b' = "xfce4"')
     except OSError:
         return 0
 


### PR DESCRIPTION
When `_is_xfce` is reached while trying to find out which desktop is running, the check always fails because `_readfrom` returns `bytes` (from `read()`) and `endswith` is being called with `str`. To avoid guessing an encoding, I changed the parameter to `bytes` as well.