### PR TITLE
Fix DeprecationWarning when importing desktop

### DIFF
--- a/desktop/__init__.py
+++ b/desktop/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: iso-8859-1 -*-
 
-"""
+r"""
 Simple desktop integration for Python. This module provides desktop environment
 detection and resource opening support for a selection of common and
 standardised desktop environments.


### PR DESCRIPTION
As the docstring on `__init__` file contains backslash, we need to make it a raw string to avoid "invalid escape sequence" DeprecationWarning to be emitted.